### PR TITLE
Find and link with thread library on system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ endif()
 
 target_link_libraries(networking_base INTERFACE compile_flags_target)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(networking_base INTERFACE Threads::Threads)
+
 # -------------------------------------------------------------
 # global include directories
 # -------------------------------------------------------------


### PR DESCRIPTION
Find and link with the right threading library on a system -- pthread was causing errors on Linux. It might be possible to narrow this down to a specific set of features that use threads, such as only when Asio and any other specific features or submodules that use threads are enabled.