### PR TITLE
add logging callbacks 

### DIFF
--- a/gmlc/networking/TcpAcceptor.cpp
+++ b/gmlc/networking/TcpAcceptor.cpp
@@ -37,7 +37,7 @@ bool TcpAcceptor::connect()
         acceptor_.bind(endpoint_, ec);
         if (ec) {
             state = AcceptingStates::OPENED;
-            logger(0,std::string("acceptor error")+ec.message());
+            logger(0, std::string("acceptor error") + ec.message());
             return false;
         }
         state = AcceptingStates::CONNECTED;
@@ -82,7 +82,7 @@ bool TcpAcceptor::start(TcpConnection::pointer conn)
         if (accepting.isActive()) {
             accepting.trigger();
         }
-        logger(0,"tcpconnection is not valid");
+        logger(0, "tcpconnection is not valid");
         return false;
     }
     if (state != AcceptingStates::CONNECTED) {
@@ -106,7 +106,7 @@ bool TcpAcceptor::start(TcpConnection::pointer conn)
         return true;
     }
 
-    logger(1,"acceptor is already active");
+    logger(1, "acceptor is already active");
     conn->close();
     return false;
 }
@@ -160,7 +160,7 @@ void TcpAcceptor::handle_accept(
         if (errorCall) {
             errorCall(std::move(ptr), error);
         } else {
-            logger(0,std::string(" error in accept::")+ error.message());
+            logger(0, std::string(" error in accept::") + error.message());
         }
         asio::socket_base::linger optionLinger(true, 0);
         try {
@@ -175,7 +175,6 @@ void TcpAcceptor::handle_accept(
         accepting.reset();
     }
 }
-
 
 void TcpAcceptor::logger(int logLevel, const std::string& message)
 {

--- a/gmlc/networking/TcpAcceptor.h
+++ b/gmlc/networking/TcpAcceptor.h
@@ -89,6 +89,10 @@ class TcpAcceptor : public std::enable_shared_from_this<TcpAcceptor> {
     {
         errorCall = std::move(errorFunc);
     }
+    /** set a logging function */
+    void setLoggingFunction(
+        std::function<void(int loglevel, const std::string& logMessage)>
+            logFunc);
     /** set an option on the underlying acceptor*/
     template<class X>
     void set_option(const X& option)
@@ -106,11 +110,14 @@ class TcpAcceptor : public std::enable_shared_from_this<TcpAcceptor> {
         TcpAcceptor::pointer ptr,
         TcpConnection::pointer new_connection,
         const std::error_code& error);
+
+    void logger(int level, const std::string& message);
     asio::ip::tcp::endpoint endpoint_;
     asio::ip::tcp::acceptor acceptor_;
     std::function<void(TcpAcceptor::pointer, TcpConnection::pointer)>
         acceptCall;
     std::function<bool(TcpAcceptor::pointer, const std::error_code&)> errorCall;
+    std::function<void(int level, const std::string& logMessage)> logFunction;
     std::atomic<AcceptingStates> state{AcceptingStates::OPENED};
     gmlc::concurrency::TriggerVariable accepting;
 };

--- a/gmlc/networking/TcpConnection.cpp
+++ b/gmlc/networking/TcpConnection.cpp
@@ -153,7 +153,7 @@ void TcpConnection::handle_read(
             }
         } else if (error != asio::error::eof) {
             if (error != asio::error::connection_reset) {
-                logger(0,std::string("receive error ") + error.message());
+                logger(0, std::string("receive error ") + error.message());
             }
             state = ConnectionStates::HALTED;
             receivingHalt.trigger();
@@ -164,12 +164,12 @@ void TcpConnection::handle_read(
     }
 }
 
-void TcpConnection::logger(int logLevel, const std::string& message) {
+void TcpConnection::logger(int logLevel, const std::string& message)
+{
     if (logFunction) {
         logFunction(logLevel, message);
     } else {
-        if (logLevel == 0)
-        {
+        if (logLevel == 0) {
             std::cerr << message << std::endl;
         } else {
             std::cout << message << '\n';
@@ -210,7 +210,7 @@ void TcpConnection::closeNoWait()
                 logger(
                     0,
                     std::string("error occurred sending shutdown::") +
-                        ec.message() + " "+std::to_string(ec.value()));
+                        ec.message() + " " + std::to_string(ec.value()));
             }
             ec.clear();
         }
@@ -278,9 +278,9 @@ void TcpConnection::connect_handler(const std::error_code& error)
         socket_.lowest_layer().set_option(asio::ip::tcp::no_delay(true));
     } else {
         std::stringstream str;
-        
+
         str << "connection error " << error.message()
-                  << ": code =" << error.value();
+            << ": code =" << error.value();
         logger(0, str.str());
         connectionError = true;
         connected.activate();
@@ -293,7 +293,7 @@ size_t TcpConnection::send(const void* buffer, size_t dataLength)
             logger(0, "connection timeout waiting again");
         }
         if (!waitUntilConnected(200ms)) {
-            logger(0,"connection timeout twice, now returning");
+            logger(0, "connection timeout twice, now returning");
             return 0;
         }
     }
@@ -311,7 +311,7 @@ size_t TcpConnection::send(const void* buffer, size_t dataLength)
         //   std::cerr << "DEBUG partial buffer sent" << std::endl;
     }
     if (count >= 5) {
-        logger(0,"TcpConnection send terminated" );
+        logger(0, "TcpConnection send terminated");
         return 0;
     }
     return dataLength;

--- a/gmlc/networking/TcpConnection.h
+++ b/gmlc/networking/TcpConnection.h
@@ -171,6 +171,8 @@ namespace networking {
         {
             callback(shared_from_this(), data.data(), message_size, error);
         }
+
+        void logger(int level, const std::string& message);
         static std::atomic<int> idcounter;
 
         std::atomic<size_t> residBufferSize{0};

--- a/gmlc/networking/TcpServer.cpp
+++ b/gmlc/networking/TcpServer.cpp
@@ -101,7 +101,7 @@ TcpServer::~TcpServer()
 void TcpServer::initialConnect()
 {
     if (halted.load(std::memory_order_acquire)) {
-        logger(0,"previously halted server");
+        logger(0, "previously halted server");
         return;
     }
     for (auto& ep : endpoints) {
@@ -126,8 +126,11 @@ void TcpServer::initialConnect()
     for (auto& acc : acceptors) {
         ++index;
         if (!acc->connect()) {
-            logger(0,std::string("unable to connect acceptor ")+std::to_string(index)+" of "
-                      +std::to_string(acceptors.size()));
+            logger(
+                0,
+                std::string("unable to connect acceptor ") +
+                    std::to_string(index) + " of " +
+                    std::to_string(acceptors.size()));
             continue;
         }
         ++connectedAcceptors;
@@ -139,8 +142,11 @@ void TcpServer::initialConnect()
         return;
     }
     if (connectedAcceptors < acceptors.size()) {
-        logger(1,std::string("partial connection on the server ") +std::to_string(connectedAcceptors)
-                  + " of " + std::to_string(acceptors.size()) + " were connected");
+        logger(
+            1,
+            std::string("partial connection on the server ") +
+                std::to_string(connectedAcceptors) + " of " +
+                std::to_string(acceptors.size()) + " were connected");
     }
 }
 
@@ -152,10 +158,15 @@ bool TcpServer::reConnect(std::chrono::milliseconds timeOut)
         if (!acc->isConnected()) {
             if (!acc->connect(timeOut)) {
                 if (partialConnect) {
-                    logger(0,std::string("unable to connect all acceptors on ")
-                              +acc->to_string());
+                    logger(
+                        0,
+                        std::string("unable to connect all acceptors on ") +
+                            acc->to_string());
                 } else {
-                    logger(0, std::string("unable to connect on ") + acc->to_string());
+                    logger(
+                        0,
+                        std::string("unable to connect on ") +
+                            acc->to_string());
                 }
 
                 halted = true;
@@ -165,7 +176,7 @@ bool TcpServer::reConnect(std::chrono::milliseconds timeOut)
         partialConnect = true;
     }
     if ((halted.load()) && (partialConnect)) {
-        logger(0,"partial connection on acceptor");
+        logger(0, "partial connection on acceptor");
     }
     return !halted;
 }
@@ -204,14 +215,14 @@ bool TcpServer::start()
 {
     if (halted.load(std::memory_order_acquire)) {
         if (!reConnect(std::chrono::milliseconds(1000))) {
-            logger(0,"reconnect failed");
+            logger(0, "reconnect failed");
             acceptors.clear();
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
             halted.store(false);
             initialConnect();
             if (halted) {
                 if (!reConnect(std::chrono::milliseconds(1000))) {
-                    logger(0,"reconnect part 2 failed");
+                    logger(0, "reconnect part 2 failed");
                     return false;
                 }
             }

--- a/gmlc/networking/TcpServer.h
+++ b/gmlc/networking/TcpServer.h
@@ -76,6 +76,10 @@ class TcpServer : public std::enable_shared_from_this<TcpServer> {
     {
         errorCall = std::move(errorFunc);
     }
+    /** set a logging function */
+    void setLoggingFunction(
+        std::function<void(int loglevel, const std::string& logMessage)>
+            logFunc);
     void handle_accept(
         TcpAcceptor::pointer acc,
         TcpConnection::pointer new_connection);
@@ -101,6 +105,8 @@ class TcpServer : public std::enable_shared_from_this<TcpServer> {
         int nominalBufferSize);
 
     void initialConnect();
+    void logger(int level, const std::string& message);
+
     asio::io_context& ioctx;
     mutable std::mutex accepting;
     std::vector<TcpAcceptor::pointer> acceptors;
@@ -109,6 +115,7 @@ class TcpServer : public std::enable_shared_from_this<TcpServer> {
     std::function<size_t(TcpConnection::pointer, const char*, size_t)> dataCall;
     std::function<bool(TcpConnection::pointer, const std::error_code& error)>
         errorCall;
+    std::function<void(int level, const std::string& logMessage)> logFunction;
     std::atomic<bool> halted{false};
     bool reuse_address = false;
     // this data structure is protected by the accepting mutex


### PR DESCRIPTION
to the main classes to eliminate direct calls to std::cout, and std::cerr