### PR TITLE
Include vector header in AsioContextManager

### DIFF
--- a/gmlc/networking/AsioContextManager.cpp
+++ b/gmlc/networking/AsioContextManager.cpp
@@ -21,6 +21,7 @@ All rights reserved. SPDX-License-Identifier: BSD-3-Clause
 #include <chrono>
 #include <iostream>
 #include <map>
+#include <vector>
 #include <mutex>
 #include <stdexcept>
 #include <thread>

--- a/gmlc/networking/AsioContextManager.h
+++ b/gmlc/networking/AsioContextManager.h
@@ -23,6 +23,7 @@ All rights reserved. SPDX-License-Identifier: BSD-3-Clause
 #include <atomic>
 #include <future>
 #include <map>
+#include <vector>
 #include <memory>
 #include <mutex>
 #include <string>


### PR DESCRIPTION
Fixes the cpplint errors from include_what_you_use about needing to `#include <vector>` in AsioContextManager source files.