### PR TITLE
Add workspace as safe directory for git for Cygwin builds

### DIFF
--- a/.github/workflows/msys2-cygwin.yml
+++ b/.github/workflows/msys2-cygwin.yml
@@ -63,9 +63,10 @@ jobs:
       with:
         platform: x86
         packages: git make cmake gcc-g++ ninja
-   
     - name: CMake Configure
-      run: cmake -G Ninja -B build -S '${{ github.workspace }}'
+      run: |
+              git config --global --add safe.directory '${{ github.workspace }}'
+              cmake -G Ninja -B build -S '${{ github.workspace }}'
 
     - name: Build
       run: cmake --build build --parallel

--- a/gmlc/networking/AsioContextManager.cpp
+++ b/gmlc/networking/AsioContextManager.cpp
@@ -25,6 +25,7 @@ All rights reserved. SPDX-License-Identifier: BSD-3-Clause
 #include <stdexcept>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace gmlc::networking {
 /** a storage system for the available core objects allowing references by name

--- a/gmlc/networking/AsioContextManager.h
+++ b/gmlc/networking/AsioContextManager.h
@@ -27,6 +27,7 @@ All rights reserved. SPDX-License-Identifier: BSD-3-Clause
 #include <mutex>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace gmlc::networking {
 /** class defining a (potential) singleton Asio io_context manager for all asio


### PR DESCRIPTION
Fix an error with the Cygwin build when cloning submodules. May caused by the code checkout happening in the context of a user on the build VM, while the git command for the CMake build step is running under Cygwin.