### PR TITLE
Have GitHub action checkout submodules for Cygwin build

### DIFF
--- a/.github/workflows/msys2-cygwin.yml
+++ b/.github/workflows/msys2-cygwin.yml
@@ -59,6 +59,9 @@ jobs:
         shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
+
     - uses: egor-tensin/setup-cygwin@v3
       with:
         platform: x86


### PR DESCRIPTION
Avoids an error with different git users causing an earlier than expected failure in the Cygwin builds.