### PR TITLE
Fix Cygwin CI build path issue

### DIFF
--- a/.github/workflows/msys2-cygwin.yml
+++ b/.github/workflows/msys2-cygwin.yml
@@ -71,10 +71,10 @@ jobs:
       run: cmake --system-information
 
     - name: Workspace source path
-      run: echo "github.workspace=${{ github.workspace }}"
+      run: echo "github.workspace=$(cygpath -u '${{ github.workspace }}')"
  
     - name: CMake Configure
-      run: cmake -G Ninja -B build -S '${{ github.workspace }}'
+      run: cmake -G Ninja -B build -S "$(cygpath -u '${{ github.workspace }}')"
 
     - name: Build
       run: cmake --build build --parallel

--- a/.github/workflows/msys2-cygwin.yml
+++ b/.github/workflows/msys2-cygwin.yml
@@ -66,7 +66,13 @@ jobs:
       with:
         platform: x86
         packages: git make cmake gcc-g++ ninja
-   
+
+    - name: CMake Info
+      run: cmake --system-information
+
+    - name: Workspace source path
+      run: echo "github.workspace=${{ github.workspace }}"
+ 
     - name: CMake Configure
       run: cmake -G Ninja -B build -S '${{ github.workspace }}'
 


### PR DESCRIPTION
Windows-style path from github.workspace needed converting to unix style (cygdrive/) using cygpath utility.