### PR TITLE
Make codespell ignore ThirdParty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     hooks:
       - id: codespell
         exclude: ^(test/|units/|docs/reference/)
+        args: ["--ignore-words-list=ThirdParty"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:


### PR DESCRIPTION
Tell codespell to ignore `ThirdParty` spelling. It's picking up a folder name.