### PR TITLE
ci: bump freebsd from 14.2 to 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 freebsd_task:
   name: freebsd
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-14-3
   only_if: $CIRRUS_BASE_BRANCH == 'main' || $CIRRUS_BRANCH == 'main' || $CIRRUS_BRANCH =~ 'freebsd[-\/].*'
   install_script: |
     pkg install -y cmake ninja git


### PR DESCRIPTION
FreeBSD 14.2 no longer works on Cirrus CI, use 14.3 instead.